### PR TITLE
Figment learn / near / 5 smart contract

### DIFF
--- a/network-documentation/near/tutorials/intro-pathway-write-and-deploy-your-first-near-smart-contract/5.-writing-and-deploying-your-first-near-smart-contract.md
+++ b/network-documentation/near/tutorials/intro-pathway-write-and-deploy-your-first-near-smart-contract/5.-writing-and-deploying-your-first-near-smart-contract.md
@@ -130,7 +130,7 @@ Now, make sure to check a few things before we continue:
 To deploy your smart contract using the CLI run the command:
 
 ```text
-near deploy \
+near dev-deploy \
   --contractName=figment-learn.testnet \
   --keyPath=./credentials/testnet/figment-learn.testnet.json \
   --wasmFile=./contract.wasm
@@ -138,12 +138,16 @@ near deploy \
 
 Where:
 
-* `--contractName` is the name of your contract, for demo purposes we use the same name as our account name, but you can pick any name you'd like \(the contract must exist though\).
+* `--contractName` is the name of your contract, for demo purposes we use the same name as our account name, but you can pick any name you'd like
 * `--keyPath` is a location of the key pair file
 * `--wasmFile` is a location of the compiled contract file
 
 {% hint style="info" %}
 For demo purposes, we are using `figment-learn.testnet` contract throughout the tutorial. Please don't forget to change the name of your contract!
+{% endhint %}
+
+{% hint style="info" %}
+For demo purposes, we are using *testnet* and the `near dev-deploy` command. To deploy to the *mainnet*, use `near deploy` instead.
 {% endhint %}
 
 The output of the command might look similar to:


### PR DESCRIPTION
Since we try to deploy a  new contract on `testnet`, I think we want to use `dev-deploy` rather than `deploy`.